### PR TITLE
fix: prevent cookie expiration reset on read

### DIFF
--- a/src/lib/index.svelte.ts
+++ b/src/lib/index.svelte.ts
@@ -152,11 +152,16 @@ export function persistedState<T>(key: string, initialValue: T, options: Options
 	}
 
 	let state = $state(storedValue);
+	let lastSerialized: string | null = storageArea?.getItem(key) ?? null;
 
 	function updateStorage(value: T) {
 		try {
 			const valueToStore = beforeWrite(value);
-			storageArea?.setItem(key, serializer.stringify(valueToStore));
+			const serialized = serializer.stringify(valueToStore);
+			if (serialized !== lastSerialized) {
+				storageArea?.setItem(key, serialized);
+				lastSerialized = serialized;
+			}
 		} catch (error) {
 			onWriteError(error);
 		}

--- a/src/presistedState.test.ts
+++ b/src/presistedState.test.ts
@@ -241,6 +241,42 @@ describe('persistedState', () => {
 		expect(JSON.parse(raw!)).toBe('cookieInitial');
 	});
 
+	it('should not rewrite cookie when value has not changed', async () => {
+		document.cookie = `cookieKey=${encodeURIComponent('"existingValue"')};path=/`;
+		const setCookieSpy = vi.spyOn(document, 'cookie', 'set');
+
+		persistedState<string>('cookieKey', 'default', { storage: 'cookie' });
+		await waitForNextTick();
+
+		expect(setCookieSpy).not.toHaveBeenCalled();
+		setCookieSpy.mockRestore();
+	});
+
+	it('should write cookie when value actually changes', async () => {
+		document.cookie = `cookieKey=${encodeURIComponent('"existingValue"')};path=/`;
+		const setCookieSpy = vi.spyOn(document, 'cookie', 'set');
+
+		const state = persistedState<string>('cookieKey', 'default', { storage: 'cookie' });
+		state.current = 'newValue';
+		await waitForNextTick();
+
+		expect(setCookieSpy).toHaveBeenCalled();
+		const raw = getCookieValue('cookieKey');
+		expect(JSON.parse(raw!)).toBe('newValue');
+		setCookieSpy.mockRestore();
+	});
+
+	it('should not rewrite localStorage when value has not changed', async () => {
+		localStorage.setItem('testKey', '"existingValue"');
+		const setItemSpy = vi.spyOn(Object.getPrototypeOf(window.localStorage), 'setItem');
+
+		persistedState<string>('testKey', 'default');
+		await waitForNextTick();
+
+		expect(setItemSpy).not.toHaveBeenCalled();
+		setItemSpy.mockRestore();
+	});
+
 	it('should not sync across tabs for cookies even if syncTabs is true', async () => {
 		const state = persistedState<string>('cookieKey', 'cookieInitial', {
 			storage: 'cookie',


### PR DESCRIPTION
This pull request optimizes the `persistedState` function to prevent unnecessary writes to storage (such as `localStorage` and cookies) when the value has not changed. It also adds comprehensive tests to ensure this behavior works correctly for both cookies and `localStorage`.

Optimizations to storage writes:

* Updated `persistedState` in `src/lib/index.svelte.ts` to track the last serialized value and only update storage when the value actually changes, reducing redundant writes.

Testing improvements:

* Added tests in `src/presistedState.test.ts` to verify that cookies and `localStorage` are not rewritten when the value has not changed, and that they are updated correctly when the value does change.